### PR TITLE
Fixed some "Unknown" responses on iOS 9.2.

### DIFF
--- a/Source/UIDevice+PasscodeStatus.m
+++ b/Source/UIDevice+PasscodeStatus.m
@@ -68,7 +68,7 @@ NSString * const UIDevicePasscodeKeychainAccount = @"UIDevice-PasscodeStatus_Key
         status = SecItemAdd((__bridge CFDictionaryRef)setQuery, NULL);
         
         // if it failed to add the item.
-        if (status == errSecDecode) {
+        if (status == errSecDecode || status == errSecAuthFailed) {
             return LNPasscodeStatusDisabled;
         }
         


### PR DESCRIPTION
Returns `LNPasscodeStatusDisabled` when `SetItemAdd` returns `errSecAuthFailed`, as it seems to do in iOS 9.2.